### PR TITLE
fix: a quick fix for a bug that was breaking discovery when attemptin…

### DIFF
--- a/orvibo/orvibo.py
+++ b/orvibo/orvibo.py
@@ -227,7 +227,10 @@ class Orvibo(object):
 
 
     def __repr__(self):
-        mac = binascii.hexlify(bytearray(self.mac))
+        if hasattr(self, 'mac'):
+            mac = binascii.hexlify(bytearray(self.mac))
+        else:
+            mac = 'Unknown'
         return "Orvibo[type={}, ip={}, mac={}]".format(self.type, self.ip, mac)
 
     @staticmethod
@@ -359,12 +362,12 @@ class Orvibo(object):
     def learn_ir(self, fname = None, timeout = 15):
         """ Backward compatibility
         """
-        return self.learn(self, fname, timeout) 
+        return self.learn(self, fname, timeout)
 
     def learn_rf433(self, fname = None, timeout = 15):
         """ Backward compatibility
         """
-        return self.learn(self, fname, timeout) 
+        return self.learn(self, fname, timeout)
 
     def learn(self, fname = None, timeout = 15):
         """ Read signal using your remote for future emit
@@ -525,7 +528,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     if ip is not None:
-        
+
         if mac is None:
             try:
                 d = Orvibo.discover(ip)


### PR DESCRIPTION
…g to print the Orbivo class to a string due to a missing self.mac property

I'm not very experienced with python but I had a go, at at least a short term fix.  The issue was occurring when attempting discovery(no mac specified).  

``` python
Traceback (most recent call last):
  File "orvibo.py", line 524, in <module>
    print(d)
  File "orvibo.py", line 230, in __repr__
    mac = binascii.hexlify(bytearray(self.mac))
AttributeError: 'Orvibo' object has no attribute 'mac'
```

The method **repr** was attempting to use "self.mac" when printing a string representation of itself.  I just added a quick check before attempting to print it, it should/could be initialised in the constructor but I wasn't sure if I was going to cause any regressions by doing that(also I don't really know python very well)

Anyway, I think it might be the print in this part of the code that is printing the object before self.mac is initialised.

``` python
if ip is None and switch is None and emitFile is None and teach is None:
        for d in Orvibo.discover().values():
            d = Orvibo(*d)
            print(d)
        sys.exit(0)
```
